### PR TITLE
made id searches consistent and update documentation

### DIFF
--- a/backend/dist/server.js
+++ b/backend/dist/server.js
@@ -60157,7 +60157,7 @@ router.route('/heatmap').get((req, res) => {
   });
 });
 
-router.route('/heatmap/:heatmap_id').get((req, res) => {
+router.route('/heatmap/id/:heatmap_id').get((req, res) => {
   Heatmap.findById(req.params.heatmap_id, (err, heatmap) => {
     if (err) res.send(err);
 
@@ -60214,7 +60214,7 @@ router.route('/zone').get((req, res) => {
   });
 });
 
-router.route('/zone/:zone_id').get((req, res) => {
+router.route('/zone/id/:zone_id').get((req, res) => {
   Zone.findById(req.params.zone_id, (err, zone) => {
     if (err) res.send(err);
 

--- a/backend/src/routes/heatmap.js
+++ b/backend/src/routes/heatmap.js
@@ -18,7 +18,7 @@ router.route('/heatmap')
     });
   });
 
-  router.route('/heatmap/:heatmap_id')
+  router.route('/heatmap/id/:heatmap_id')
     .get((req,res) => {
       Heatmap.findById(req.params.heatmap_id, (err, heatmap) => {
         if(err)

--- a/backend/src/routes/zone.js
+++ b/backend/src/routes/zone.js
@@ -18,7 +18,7 @@ router.route('/zone')
     });
   });
 
-  router.route('/zone/:zone_id')
+  router.route('/zone/id/:zone_id')
     .get((req,res) => {
       Zone.findById(req.params.zone_id, (err, zone) => {
         if(err)

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@
 - [Zone](#Zone)
 - [Heatmap](#Heatmap)
 
-### Domain 
+### Domain
 
 **GET** /domain - Returns all domains in the database
 
@@ -24,7 +24,7 @@
 
 **GET** /zone - Returns all zones in the database
 
-**GET** /zone/*{zoneId}* - Returns on domain that matches the zone ID.
+**GET** /zone/id/*{zoneId}* - Returns on domain that matches the zone ID.
 
 **GET** /zone/date/*{dateCreated}* - Returns one domain that matches date created.
 
@@ -34,7 +34,7 @@
 
 **GET** /Heatmap - Returns all heatmaps in the database
 
-**GET** /heatmap/*{heatmapId}* - returns one domain that matches the heatmap id.
+**GET** /heatmap/id/*{heatmapId}* - returns one domain that matches the heatmap id.
 
 **GET** /heatmap/date/*{dateCreated}* - returns on heatmaps that matches the heatmap ID.
 


### PR DESCRIPTION
Made both zone and domain API routes use /api/zone/id/{_id} or /api/heatmap/id/{_id} depending on the information the user is trying to get back. Updated documentation to reflect these changes. 